### PR TITLE
Fix use with Python:3.10

### DIFF
--- a/elastictabstops/classes.py
+++ b/elastictabstops/classes.py
@@ -6,7 +6,13 @@
 #  * it doesn't follow the Maximum Line Length rule
 # use pylint as following: pylint --indent-string='\t' --max-line-length=1000 elastictabstops
 
-from collections import Sequence
+# Abstract Base Classes ("abc") of the "collection" module were moved to "collections.abc" 
+# with Python:3.3, see https://docs.python.org/3.9/library/collections.html#module-collections
+import sys
+if sys.version_info.major >= 3 and sys.version_info.minor >= 3:
+    from collections.abc import Sequence
+else:
+    from collections import Sequence
 
 from elastictabstops.convert import _from_spaces, _from_elastic_tabstops, _from_fixed_tabstops, _to_spaces, _to_elastic_tabstops, _to_fixed_tabstops
 

--- a/elastictabstops/classes.py
+++ b/elastictabstops/classes.py
@@ -10,9 +10,9 @@
 # with Python:3.3, see https://docs.python.org/3.9/library/collections.html#module-collections
 import sys
 if sys.version_info.major >= 3 and sys.version_info.minor >= 3:
-    from collections.abc import Sequence
+	from collections.abc import Sequence
 else:
-    from collections import Sequence
+	from collections import Sequence
 
 from elastictabstops.convert import _from_spaces, _from_elastic_tabstops, _from_fixed_tabstops, _to_spaces, _to_elastic_tabstops, _to_fixed_tabstops
 


### PR DESCRIPTION
Abstract Base Classes ("abc") were moved from the "collections" module into the "collectios.abc" module in [Python:3.3][1]. Between Python:3.3 and Python:3.9 the use of them was still possible but deprecated. With Python:3.10 the Base Classes were removed completely and thus rendered *elastictabstops* broken.

```
# python
Python 3.10.7 (main, Oct  5 2022, 10:41:54) [GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from elastictabstops import classes
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/src/elastictabstops/__init__.py", line 12, in <module>
    from elastictabstops.classes import Text, Table
  File "/src/elastictabstops/classes.py", line 9, in <module>
    from collections import Sequence
ImportError: cannot import name 'Sequence' from 'collections' (/usr/local/lib/python3.10/collections/__init__.py)
```

This commit addresses the issue by using a guarded import statement.

[1]: https://docs.python.org/3.9/library/collections.html#module-collections